### PR TITLE
accept any key type that borrows to the real key type

### DIFF
--- a/tests/cycle_map_tests.rs
+++ b/tests/cycle_map_tests.rs
@@ -260,20 +260,20 @@ mod tests {
         assert_eq!(
             iter.cloned().collect::<HashSet<TestingStruct>>(),
             (0..10)
-                .map(|i| TestingStruct::from_value(i))
+                .map(TestingStruct::from_value)
                 .collect::<HashSet<TestingStruct>>()
         );
     }
 
     #[test]
     fn drain_tests() {
-        let mut map: CycleMap<u64, String> = (0..100).map(|i| (i,i.to_string())).collect();
+        let mut map: CycleMap<u64, String> = (0..100).map(|i| (i, i.to_string())).collect();
         let cap = map.capacity();
         let other_map: CycleMap<u64, String> = map.drain().collect();
         assert_eq!(map.len(), 0);
         assert_eq!(map.capacity(), cap);
         assert_eq!(other_map.len(), 100);
-        let mut map: CycleMap<u64, String> = (0..100).map(|i| (i,i.to_string())).collect();
+        let mut map: CycleMap<u64, String> = (0..100).map(|i| (i, i.to_string())).collect();
         let other_map: CycleMap<u64, String> = map.drain_filter(|l, _| l % 2 == 0).collect();
         assert_eq!(map.len(), 50);
         assert_eq!(other_map.len(), 50);
@@ -288,7 +288,7 @@ mod tests {
         assert_eq!(map.clone(), construct_default_map());
         assert_eq!(construct_default_map(), construct_default_map());
     }
-    
+
     #[test]
     fn shrink_tests() {
         let mut map: CycleMap<i32, i32> = CycleMap::with_capacity(100);
@@ -316,7 +316,7 @@ mod tests {
         assert!(map.capacity() >= 2);
         assert!(map.capacity() <= 10);
     }
-    
+
     #[test]
     fn reserve_tests() {
         let mut map: CycleMap<&str, i32> = CycleMap::new();

--- a/tests/group_map.rs
+++ b/tests/group_map.rs
@@ -43,24 +43,24 @@ mod tests {
         let mut map: GroupMap<String, usize> = GroupMap::new();
 
         // Simple insert
-        for i in 0..10 {
+        (0..10).for_each(|i| {
             map.insert(i.to_string(), i);
             assert!(map.are_paired(&i.to_string(), &i));
-        }
+        });
 
         // Should be the same as calling insert_right
-        for i in 0..10 {
+        (0..10).for_each(|i| {
             map.insert(vals[i].to_string(), i);
             assert!(map.are_paired(&i.to_string(), &i));
             assert!(map.are_paired(&vals[i].to_string(), &i));
-        }
+        });
 
         // Repair existing left items with new right items
-        for i in 0..10 {
+        (0..10).for_each(|i| {
             map.insert(i.to_string(), 10 * i);
             assert!(!map.are_paired(&i.to_string(), &i));
             assert!(map.contains_right(&i));
-        }
+        });
 
         // Pair existing left and right items
         for i in 1..10 {
@@ -86,46 +86,58 @@ mod tests {
             println!("{val}, {s}");
         }
     }
-    
+
     #[test]
     fn swap_right_remove_tests() {
         let mut map: GroupMap<String, TestingStruct> = construct_default_map();
-        
+
         // Should be equivalent to insert_right
         for i in 20..30 {
-            let opt = map.swap_right_remove(&TestingStruct::from_value(i-10), TestingStruct::from_value(i));
+            let opt = map.swap_right_remove(
+                &TestingStruct::from_value(i - 10),
+                TestingStruct::from_value(i),
+            );
             assert!(opt.is_none());
             assert!(map.contains_right(&TestingStruct::from_value(i)));
             assert!(!map.is_right_paired(&TestingStruct::from_value(i)));
         }
-        
+
         // Actually swap values
         for i in 10..20 {
-            let opt = map.swap_right_remove(&TestingStruct::from_value(i-10), TestingStruct::from_value(i));
-            assert_eq!(opt, Some(TestingStruct::from_value(i-10)));
-            assert!(map.are_paired(&(i-10).to_string(), &TestingStruct::from_value(i)));
-            assert!(!map.contains_right(&TestingStruct::from_value(i-10)));
-            assert!(!map.is_right_paired(&TestingStruct::from_value(i-10)));
+            let opt = map.swap_right_remove(
+                &TestingStruct::from_value(i - 10),
+                TestingStruct::from_value(i),
+            );
+            assert_eq!(opt, Some(TestingStruct::from_value(i - 10)));
+            assert!(map.are_paired(&(i - 10).to_string(), &TestingStruct::from_value(i)));
+            assert!(!map.contains_right(&TestingStruct::from_value(i - 10)));
+            assert!(!map.is_right_paired(&TestingStruct::from_value(i - 10)));
         }
     }
-    
+
     #[test]
     fn swap_right_tests() {
         let mut map: GroupMap<String, TestingStruct> = construct_default_map();
-        
+
         // Should be equivalent to insert_right
         for i in 20..30 {
-            map.swap_right(&TestingStruct::from_value(i-10), TestingStruct::from_value(i));
+            map.swap_right(
+                &TestingStruct::from_value(i - 10),
+                TestingStruct::from_value(i),
+            );
             assert!(map.contains_right(&TestingStruct::from_value(i)));
             assert!(!map.is_right_paired(&TestingStruct::from_value(i)));
         }
-        
+
         // Actually swap values
         for i in 10..20 {
-            map.swap_right(&TestingStruct::from_value(i-10), TestingStruct::from_value(i));
-            assert!(map.are_paired(&(i-10).to_string(), &TestingStruct::from_value(i)));
-            assert!(map.contains_right(&TestingStruct::from_value(i-10)));
-            assert!(!map.is_right_paired(&TestingStruct::from_value(i-10)));
+            map.swap_right(
+                &TestingStruct::from_value(i - 10),
+                TestingStruct::from_value(i),
+            );
+            assert!(map.are_paired(&(i - 10).to_string(), &TestingStruct::from_value(i)));
+            assert!(map.contains_right(&TestingStruct::from_value(i - 10)));
+            assert!(!map.is_right_paired(&TestingStruct::from_value(i - 10)));
         }
     }
 
@@ -250,7 +262,7 @@ mod tests {
         assert_eq!(
             iter.cloned().collect::<HashSet<TestingStruct>>(),
             (0..10)
-                .map(|i| TestingStruct::from_value(i))
+                .map(TestingStruct::from_value)
                 .collect::<HashSet<TestingStruct>>()
         );
     }

--- a/tests/partial_cycle_map_tests.rs
+++ b/tests/partial_cycle_map_tests.rs
@@ -292,11 +292,8 @@ mod tests {
         assert_eq!(map.len_right(), 50);
         for op in map.iter() {
             println!("{op:?}");
-            match op {
-                SomeBoth(val, _) => {
-                    assert_eq!(val % 2, 1);
-                }
-                _ => {}
+            if let SomeBoth(val, _) = op {
+                assert_eq!(val % 2, 1);
             }
         }
     }
@@ -329,11 +326,8 @@ mod tests {
         assert_eq!(map.len_right(), 34);
         for op in map.iter() {
             println!("{op:?}");
-            match op {
-                SomeLeft(val) => {
-                    assert_eq!(val % 2, 1);
-                }
-                _ => {}
+            if let SomeLeft(val) = op {
+                assert_eq!(val % 2, 1);
             }
         }
     }
@@ -370,7 +364,7 @@ mod tests {
         assert_eq!(
             iter.cloned().collect::<HashSet<TestingStruct>>(),
             (0..10)
-                .map(|i| TestingStruct::from_value(i))
+                .map(TestingStruct::from_value)
                 .collect::<HashSet<TestingStruct>>()
         );
     }
@@ -449,62 +443,62 @@ mod tests {
         for i in 0..5 {
             assert!(map.pair(&i.to_string(), &TestingStruct::from_value(i)));
         }
-        
+
         // Try to unpair items that don't exist
         assert!(!map.unpair(&10.to_string(), &TestingStruct::from_value(0)));
         assert!(!map.unpair(&0.to_string(), &TestingStruct::from_value(10)));
         assert!(!map.unpair(&10.to_string(), &TestingStruct::from_value(10)));
-        
+
         // Try to unpair unpaired items
         assert!(!map.unpair(&0.to_string(), &TestingStruct::from_value(5)));
         assert!(!map.unpair(&5.to_string(), &TestingStruct::from_value(0)));
         assert!(!map.unpair(&5.to_string(), &TestingStruct::from_value(5)));
-        
+
         // Try to unpair unpaired items
         assert!(map.unpair(&0.to_string(), &TestingStruct::from_value(0)));
         assert!(!map.are_paired(&0.to_string(), &TestingStruct::from_value(0)));
     }
-    
+
     #[test]
     fn remove_left_tests() {
         let mut map = construct_unpaired_map();
         for i in 0..5 {
             assert!(map.pair(&i.to_string(), &TestingStruct::from_value(i)));
         }
-        
+
         // Try to remove an item that isn't there
         let opt = map.remove_left(&10.to_string());
         assert!(opt.is_none());
-        
+
         // Remove a paired item
         let opt = map.remove_left(&0.to_string());
         assert_eq!(opt, Some(0.to_string()));
         assert!(!map.contains_left(&0.to_string()));
         assert!(map.contains_right(&TestingStruct::from_value(0)));
-        
+
         // Remove an unpaired item
         let opt = map.remove_left(&5.to_string());
         assert_eq!(opt, Some(5.to_string()));
         assert!(!map.contains_left(&5.to_string()));
     }
-    
+
     #[test]
     fn remove_right_tests() {
         let mut map = construct_unpaired_map();
         for i in 0..5 {
             assert!(map.pair(&i.to_string(), &TestingStruct::from_value(i)));
         }
-        
+
         // Try to remove an item that isn't there
         let opt = map.remove_right(&TestingStruct::from_value(10));
         assert!(opt.is_none());
-        
+
         // Remove a paired item
         let opt = map.remove_right(&TestingStruct::from_value(0));
         assert_eq!(opt, Some(TestingStruct::from_value(0)));
         assert!(!map.contains_right(&TestingStruct::from_value(0)));
         assert!(map.contains_left(&0.to_string()));
-        
+
         // Remove an unpaired item
         let opt = map.remove_right(&TestingStruct::from_value(5));
         assert_eq!(opt, Some(TestingStruct::from_value(5)));


### PR DESCRIPTION
As requested in #3, this PR allows using any key type that has the same hash as the real key type, exactly as `std::collections::HashMap` and `HashBrown` does